### PR TITLE
Out of sample testing

### DIFF
--- a/tools/model.py
+++ b/tools/model.py
@@ -573,6 +573,7 @@ if __name__ == "__main__":
         description="Train nonlinear PSYS model and distill to kernel-friendly linear+multi-LUT params."
     )
     parser.add_argument("logfiles", nargs="+", type=Path)
+    parser.add_argument("--test-data", type=Path, help="Optional separate dataset for testing")
     parser.add_argument("--mode", choices=("delta",), default="delta")
     parser.add_argument("--alpha", type=float, default=10.0, help="L2 strength for non-negative linear fit")
     parser.add_argument("--test-frac", type=float, default=0.2)

--- a/tools/model.py
+++ b/tools/model.py
@@ -243,9 +243,13 @@ def trim_by_quantile(
     if quantile >= 1.0:
         return train_df, test_df
     q = train_df["target_uj"].quantile(quantile)
+    low = train_df["target_uj"].quantile(1 - quantile)
+    high = train_df["target_uj"].quantile(quantile)
+
+
     return (
-        train_df[train_df["target_uj"] <= q],
-        test_df[test_df["target_uj"] <= q],
+        train_df[(train_df["target_uj"] >= low) & (train_df["target_uj"] <= high)],
+        test_df[(test_df["target_uj"] >= low) & (test_df["target_uj"] <= high)],
     )
 
 
@@ -393,6 +397,7 @@ def main() -> None:
         description="Train nonlinear PSYS model and distill to kernel-friendly linear+multi-LUT params."
     )
     parser.add_argument("logfiles", nargs="+", type=Path)
+    parser.add_argument("--test-data", type=Path, help="Optional separate dataset for testing")
     parser.add_argument("--mode", choices=("delta",), default="delta")
     parser.add_argument("--alpha", type=float, default=10.0, help="L2 strength for non-negative linear fit")
     parser.add_argument("--test-frac", type=float, default=0.2)
@@ -401,15 +406,26 @@ def main() -> None:
     parser.add_argument("--random-seed", type=int, default=42)
     args = parser.parse_args()
 
+    # Check all files exist
     for path in args.logfiles:
         if not path.exists():
             raise FileNotFoundError(path)
+    if args.test_data and not args.test_data.exists():
+        raise FileNotFoundError(args.test_data)
 
-    df = gather_rows(args.logfiles, args.mode, args.min_target_uj)
-    if df.empty or len(df) < 40:
+    # Gather training data
+    train_df = gather_rows(args.logfiles, args.mode, args.min_target_uj)
+    if train_df.empty or len(train_df) < 40:
         raise RuntimeError("Not enough usable rows (need >= 40 after filtering)")
 
-    train_df, test_df = split_random(df, args.test_frac, args.random_seed)
+    # Gather test data
+    if args.test_data:
+        test_df = gather_rows([args.test_data], args.mode, args.min_target_uj)
+        if test_df.empty:
+            raise RuntimeError("No usable rows in test-data file")
+    else:
+        train_df, test_df = split_random(train_df, args.test_frac, args.random_seed)
+
     train_df, test_df = trim_by_quantile(train_df, test_df, args.trim_upper_quantile)
     if train_df.empty or test_df.empty:
         raise RuntimeError("Train/test split produced an empty set")
@@ -505,7 +521,7 @@ def main() -> None:
     )
 
     print(f"# mode={args.mode} alpha={args.alpha}")
-    print(f"# rows_total={len(df)} rows_train={len(train_df)} rows_test={len(test_df)}")
+    print(f"# rows_train={len(train_df)} rows_test={len(test_df)}")
 
     print_metrics("test metrics (current module defaults)", metric_bundle(y_test, pred_baseline_test))
     print_metrics("test metrics (linear non-negative ridge)", metric_bundle(y_test, pred_lin_test))

--- a/tools/model.py
+++ b/tools/model.py
@@ -11,7 +11,7 @@ import pandas as pd
 from scipy.optimize import lsq_linear
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
-
+import plotext as plt
 
 NL_LUT_BINS = 8
 
@@ -408,6 +408,18 @@ def main(args) -> None:
     if train_df.empty or len(train_df) < 40:
         raise RuntimeError("Not enough usable rows (need >= 40 after filtering)")
 
+    if args.plot:
+        x = train_df["timestamp"].tolist()
+        y = train_df["target_uj"].tolist()
+
+        plt.clear_data()
+        plt.plot(x, y, marker='dot')
+        plt.title("Energy of time")
+        plt.xlabel("Time")
+        plt.ylabel(TARGET_COL)
+        plt.show()
+        return
+
     # Gather test data
     if args.test_data:
         test_df = gather_rows([args.test_data], args.mode, args.min_target_uj)
@@ -581,6 +593,7 @@ if __name__ == "__main__":
     parser.add_argument("--trim-upper-quantile", type=float, default=0.999)
     parser.add_argument("--random-seed", type=int, default=42)
     parser.add_argument("--target", type=str, choices=["rapl_psys_sum_uj", "rapl_core_sum_uj"], default="rapl_psys_sum_uj")
+    parser.add_argument("--plot", action='store_true')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR builds upon the bin approach in https://github.com/green-kernel/procpower/pull/4

It adds the `--test-data` param that points to a testing only energy logger data file.

This allows proper out of sample testing.

First results show this for non same workloads (idle vs benchmark.sh):

```log
python3 model.py /tmp/energy-7hyUsZ9f.log --mode delta --alpha 10 --trim=1.0 --test-data /tmp/energy-3G05W1dt.log
# mode=delta alpha=10.0
# rows_train=1326 rows_test=418

# --- test metrics (current module defaults) ---
R2     : -15.25236
RMSE   : 946323.788 uJ
MAE    : 916790.084 uJ
MAPE   : 99.927 %

# --- test metrics (linear non-negative ridge) ---
R2     : -12.23006
RMSE   : 853812.158 uJ
MAE    : 830840.973 uJ
MAPE   : 100.021 %

# --- test metrics (nonlinear reference) ---
R2     : -0.43362
RMSE   : 281059.228 uJ
MAE    : 254916.150 uJ
MAPE   : 29.056 %

# --- test metrics (distilled kernel model) ---
R2     : -31.53800
RMSE   : 1338988.676 uJ
MAE    : 795537.625 uJ
MAPE   : 94.943 %

# --- train metrics (distilled kernel model) ---
R2     : -575.81784
RMSE   : 44334482.657 uJ
MAE    : 2338971.645 uJ
MAPE   : 79.459 %
```

For repeated runs of benchmark.sh it is this:

```log
arne@framebook:~/Sites/procpower/tools$ python3 model.py /tmp/energy-7hyUsZ9f.log --mode delta --alpha 10 --trim=1.0 --test-data /tmp/energy-gKpkxu81.log
# mode=delta alpha=10.0
# rows_train=1326 rows_test=1246

# --- test metrics (current module defaults) ---
R2     : -2.88214
RMSE   : 3388222.120 uJ
MAE    : 2922949.824 uJ
MAPE   : 99.826 %

# --- test metrics (linear non-negative ridge) ---
R2     : 0.86565
RMSE   : 630306.004 uJ
MAE    : 576792.573 uJ
MAPE   : 32.694 %

# --- test metrics (nonlinear reference) ---
R2     : 0.96917
RMSE   : 301920.783 uJ
MAE    : 261693.641 uJ
MAPE   : 12.957 %

# --- test metrics (distilled kernel model) ---
R2     : 0.20774
RMSE   : 1530631.787 uJ
MAE    : 625044.750 uJ
MAPE   : 33.205 %

# --- train metrics (distilled kernel model) ---
R2     : -575.81784
RMSE   : 44334482.657 uJ
MAE    : 2338971.645 uJ
MAPE   : 79.459 %
```